### PR TITLE
Setup decision records + template

### DIFF
--- a/docs/decisions/0000--template.md
+++ b/docs/decisions/0000--template.md
@@ -1,0 +1,104 @@
+<!-- 
+    Template adapted from the short version example: https://adr.github.io/madr/examples.html
+    Used under CC0 license (does not require attribution etc., but included here as good practice).
+
+    Note that this template is likely to evolve over time as we gain experience with it and decide what works best.
+-->
+
+# (CHANGE ME) DECISION TEMPLATE TITLE
+
+## Context and Problem Statement
+
+<!-- Brief summary in a handful of sentences. -->
+<!-- Use whatever format/structure makes sense at the time - placeholders below are just a suggestion. -->
+
+- Situation:
+  - ...
+- Background:
+  - ...
+
+
+### Related decisions:
+
+<!-- For example, if superseding a previous decision refer to it here and edit the previous decision to refer forward to this one. -->
+
+- N/A
+
+
+## Considered Options
+
+<!-- List of options considered. -->
+<!-- Not doing an exhaustive search or relying on personal preference/experience is okay, just say so. -->
+<!-- Where relevant/possible, reference service/profession standards and project requirements/goals in any rationale provided. -->
+
+-
+
+
+## Decision Outcome
+
+Chosen option: [...], because:
+
+-
+
+
+## Decision Type
+
+<!-- This gives an indication of the level of team scrutiny/consultation. -->
+<!-- Particularly relevant where retrospectively considering past decisions and suggesting changes of direction. -->
+
+- [ ] Log of independent decision *(e.g., adoption of department/team/profession standard, no consultation/discussion needed)*
+- [ ] Log of informal decision between two or more team members *(e.g., during pair-programming session)*
+- [ ] Log of formal work *(e.g., explicit spike)*
+- [ ] Log of formal team consultation/decision process *(e.g., retrospective outcome)*
+- [ ] Log of external consultation/decision process *(e.g., policy requirement or user research outcome)*
+
+
+## Relevant/applicable service standards and profession guidance:
+
+<!-- 
+  Not every decision will need to link to external standards/guidance, but 
+  being explicit and deliberate in linking to service standards and profession-specific guidance 
+  is one way to demonstrate we actively consider them in the work we do.
+-->
+
+
+- Not considered (or N/A)
+<!--
+- [ ] [Standard point 1 - Understand users and their needs](https://apply-the-service-standard.education.gov.uk/service-standard/1-understand-user-needs)
+  - Rationale/brief notes/quotes: ...
+- [ ] [Standard point 2 - Solve a whole problem for users](https://apply-the-service-standard.education.gov.uk/service-standard/2-solve-a-whole-problem)
+  - Rationale/brief notes/quotes: ...
+- [ ] [Standard point 3 - Provide a joined-up experience across all channels](https://apply-the-service-standard.education.gov.uk/service-standard/3-joined-up-across-channels)
+  - Rationale/brief notes/quotes: ...
+- [ ] [Standard point 4 - Make the service simple to use](https://apply-the-service-standard.education.gov.uk/service-standard/4-make-the-service-simple-to-use)
+  - Rationale/brief notes/quotes: ...
+- [ ] [Standard point 5 - Make sure everyone can use the service](https://apply-the-service-standard.education.gov.uk/service-standard/5-make-sure-everyone-can-use-the-service)
+  - Rationale/brief notes/quotes: ...
+- [ ] [Standard point 6 - Have a multidisciplinary team](https://apply-the-service-standard.education.gov.uk/service-standard/6-have-a-multidisciplinary-team)
+  - Rationale/brief notes/quotes: ...
+- [ ] [Standard point 7 - Use agile ways of working](https://apply-the-service-standard.education.gov.uk/service-standard/7-use-agile-ways-of-working)
+  - Rationale/brief notes/quotes: ...
+- [ ] [Standard point 8 - Iterate and improve frequently](https://apply-the-service-standard.education.gov.uk/service-standard/8-iterate-and-improve-frequently)
+  - Rationale/brief notes/quotes: ...
+- [ ] [Standard point 9 - Create a secure service which protects users' privacy](https://apply-the-service-standard.education.gov.uk/service-standard/8-iterate-and-improve-frequently)
+  - Rationale/brief notes/quotes: ...
+- [ ] [Standard point 10 - Define what success looks like and publish performance data](https://apply-the-service-standard.education.gov.uk/service-standard/10-define-success-publish-performance-data)
+  - Rationale/brief notes/quotes: ...
+- [ ] [Standard point 11 - Choose the right tools and technology](https://apply-the-service-standard.education.gov.uk/service-standard/11-choose-the-right-tools-and-technology)
+  - Rationale/brief notes/quotes: ...
+- [ ] [Standard point 12 - Make new source code open](https://apply-the-service-standard.education.gov.uk/service-standard/12-make-new-source-code-open)
+  - Rationale/brief notes/quotes: ...
+- [ ] [Standard point 13 - Use and contribute to open standards, common components and patterns](https://apply-the-service-standard.education.gov.uk/service-standard/13-use-common-standards-components-patterns)
+  - Rationale/brief notes/quotes: ...
+- [ ] [Standard point 14 - Operate a reliable service](https://apply-the-service-standard.education.gov.uk/service-standard/14-operate-a-reliable-service)
+  - Rationale/brief notes/quotes: ...
+-->
+
+
+## Change History
+
+*See git commit history for merge timings and full diffs.*
+
+Human notes:
+- Initial write-up/submission/proposal
+

--- a/docs/decisions/0001--use-markdown-any-decision-records.md
+++ b/docs/decisions/0001--use-markdown-any-decision-records.md
@@ -1,0 +1,82 @@
+<!-- 
+    Template adapted from the short version example: https://adr.github.io/madr/examples.html
+    Used under CC0 license (does not require attribution etc., but included here as good practice).
+
+    Note that this template is likely to evolve over time as we gain experience with it and decide what works best.
+-->
+
+# Use Markdown Any Decision Records (MADRs)
+
+## Context and Problem Statement
+
+_NOTE: This decision record and template is adapted from:_
+https://github.com/adr/madr/blob/develop/docs/decisions/0000-use-markdown-any-decision-records.md?plain=1
+
+<!-- Brief summary in a handful of sentences. -->
+<!-- Use whatever format/structure makes sense at the time - placeholders below are just a suggestion. -->
+
+- We want to record any decisions made in this project independent whether decisions concern the architecture ("architectural decision record"), the code, or any other .
+- Which format and structure should these records follow?
+
+
+### Related decisions:
+
+- N/A
+
+
+## Considered Options
+
+<!-- Variable length list of options considered. Not doing an exhaustive search is okay, just say so. -->
+
+- [MADR](https://adr.github.io/madr/) 3.0.0 – The Markdown Any Decision Records
+- [Michael Nygard's template](http://thinkrelevance.com/blog/2011/11/15/documenting-architecture-decisions) – The first incarnation of the term "ADR"
+- [Sustainable Architectural Decisions](https://www.infoq.com/articles/sustainable-architectural-design-decisions) – The Y-Statements
+- Other templates listed at <https://github.com/joelparkerhenderson/architecture_decision_record>
+- Formless – No conventions for file format and structure
+
+
+
+## Decision Outcome
+
+Chosen option: "MADR 3.0.0", because:
+
+- Implicit assumptions should be made explicit.
+  Design documentation is important to enable people understanding the decisions later on.
+  See also [A rational design process: How and why to fake it](https://doi.org/10.1109/TSE.1986.6312940).
+- MADR allows for structured capturing of any decision.
+- The MADR format is lean and fits our development style.
+- The MADR structure is comprehensible and facilitates usage & maintenance.
+- The MADR project is vivid.
+
+
+## Decision Type / Level of Team Scrutiny
+
+- [X] Log of independent decision *(e.g., adoption of department/team/profession standard, no consultation/discussion needed)*
+- [ ] Log of informal decision between two or more team members *(e.g., during pair-programming session)*
+- [ ] Log of formal work *(e.g., explicit spike)*
+- [ ] Log of formal team consultation/decision process *(e.g., retrospective outcome)*
+
+
+## Relevant/applicable service standards _(non-exhaustive)_:
+
+- [X] [Standard point 11 - Choose the right tools and technology](https://apply-the-service-standard.education.gov.uk/service-standard/11-choose-the-right-tools-and-technology)
+  - [GOV.UK Service Manual - Point 11](https://www.gov.uk/service-manual/service-standard/point-11-choose-the-right-tools-and-technology):
+    - > be able to show that they’ve made good decisions about what technology to build and what to buy
+  - [DfE Apply the Standard - Point 11](https://apply-the-service-standard.education.gov.uk/service-standard/11-choose-the-right-tools-and-technology):
+    - > evidence that the team have considered different options to how the service will be delivered technically and the rationale for the chosen technical direction
+    - > evidence that the team will continue to re-evaluate and challenge previous decisions as new requirements are discovered 
+  - [DfE Architecture](https://dfe-digital.github.io/architecture/standards/architecture-documentation/#architecture-documentation):
+    - > architectural artefacts, decisions (opens in new tab) and plans have been documented, shared across your community and reviewed and assured
+- [X] [Standard point 13 - Use and contribute to open standards, common components and patterns](https://apply-the-service-standard.education.gov.uk/service-standard/13-use-common-standards-components-patterns)
+  - MADR is the preferred DfE option within the DfE architecture community.
+    > In DfE, we favour the Markdown Architecture Decision Records (MADR) approach, though appreciate any implementation is better than none.
+- [X] [Standard point 14 - Operate a reliable service](https://apply-the-service-standard.education.gov.uk/service-standard/14-operate-a-reliable-service)
+
+
+## Change History
+
+*See git commit history for merge timings and full diffs.*
+
+Human notes:
+- Initial write-up based on https://github.com/adr/madr/blob/develop/docs/decisions/0000-use-markdown-any-decision-records.md?plain=1
+

--- a/docs/decisions/readme.md
+++ b/docs/decisions/readme.md
@@ -1,0 +1,7 @@
+
+## Decisions
+
+- [ADR 0001 - Use MADRs](0001--use-markdown-any-decision-records.md)
+  - [MADR TEMPLATE](./0000--template.md)
+- [ADR 0002 - Default to using Draw.io/Diagrams.net for diagrams](0002--default-to-draw-io-for-diagrams.md)
+


### PR DESCRIPTION
Logging decision records centrally is "a good thing" (TM).

This pull request sets up a template (which can be fully used/abused/ignored as desired) to start logging decisions (big and small). The important thing is to get it logged in the first place. Once it's logged, it can be debated/tweaked/refined.

See additional notes/rationales etc within the file `docs/decisions/0001--use-markdown-any-decision-records.md`.