### PR TITLE
Add basic HTML for the entry page into booking a new assessment

### DIFF
--- a/src/ServiceAssessmentService/ServiceAssessmentService.WebApp/Controllers/BookController.cs
+++ b/src/ServiceAssessmentService/ServiceAssessmentService.WebApp/Controllers/BookController.cs
@@ -1,0 +1,18 @@
+﻿using Microsoft.AspNetCore.Mvc;
+
+namespace ServiceAssessmentService.WebApp.Controllers;
+
+public class BookController : Controller
+{
+    private readonly ILogger<BookController> _logger;
+
+    public BookController(ILogger<BookController> logger)
+    {
+        _logger = logger;
+    }
+
+    public IActionResult Index()
+    {
+        return View();
+    }
+}

--- a/src/ServiceAssessmentService/ServiceAssessmentService.WebApp/Views/Book/Index.cshtml
+++ b/src/ServiceAssessmentService/ServiceAssessmentService.WebApp/Views/Book/Index.cshtml
@@ -1,0 +1,140 @@
+﻿@{
+    ViewData["Title"] = "Index";
+}
+
+<div class="main--content">
+
+    <div class="main--inside-container">
+
+        <div class="govuk-grid-row">
+            <div class="govuk-grid-column-full">
+                <h1 class="govuk-heading-l ">Book a discovery peer review</h1>
+            </div>
+        </div>
+
+        <div class="govuk-grid-row">
+            <div class="govuk-grid-column-two-thirds">
+
+                <p>You can use this service to:</p>
+
+                <ul class="govuk-list govuk-list--bullet">
+                    <li>book an end of discovery peer review, do this at least 5 weeks in advance</li>
+                    <li>update the project details, for example, the name of a discovery</li>
+                    <li>read reports of all DfE discovery peer reviews</li>
+                    <li>provide input to reports as an assessor</li>
+                </ul>
+
+                <h2 class="govuk-heading-m">Start a request</h2>
+
+                <p>If you want to, you can check the <a href="/generic/assessments">assessments section</a> to see if a request has already been submitted for your discovery.</p>
+
+                <p>You can book a discovery peer review for your own project or on behalf of a team.</p>
+
+                <a href="/book/request/name-of-discovery" role="button" draggable="false" class="govuk-button govuk-button--start" data-module="govuk-button">
+                    Start now
+                    <svg class="govuk-button__start-icon" xmlns="http://www.w3.org/2000/svg" width="17.5" height="19" viewBox="0 0 33 40" aria-hidden="true" focusable="false">
+                        <path fill="currentColor" d="M0 0h13l20 20-20 20H0l20-20z"></path>
+                    </svg>
+                </a>
+
+
+                @* 
+                <div class="govuk-summary-card">
+                    <div class="govuk-summary-card__title-wrapper">
+                        <h2 class="govuk-summary-card__title">Continue with a draft</h2>
+                    </div>
+                    <div class="govuk-summary-card__content">
+                        <table class="dfeuk-table dfeuk-table-responsive dfeuk-table--smaller">
+                            <thead class="dfeuk-table__head">
+                                <tr class="dfeuk-table__row">
+                                    <th scope="col" class="dfeuk-table__header govuk-!-width-one-third">Service</th>
+                                    <th scope="col" class="dfeuk-table__header">Phase</th>
+                                    <th scope="col" class="dfeuk-table__header">Started</th>
+                                    <th scope="col" class="dfeuk-table__header">Last updated</th>
+                                </tr>
+                            </thead>
+                            <tbody class="dfeuk-table__body">
+
+                                <tr class="dfeuk-table__row">
+                                    <th scope="row" class="dfeuk-table__header">
+                                        <a href="/book/draft/recSWTLYkqQNCdXLh">app</a>
+                                    </th>
+                                    <td class="dfeuk-table__cell">Discovery</td>
+                                    <td class="dfeuk-table__cell">12 Oct 2023</td>
+                                    <td class="dfeuk-table__cell">12 Oct 2023</td>
+                                </tr>
+
+                                <tr class="dfeuk-table__row">
+                                    <th scope="row" class="dfeuk-table__header">
+                                        <a href="/book/draft/recYXytdddLcPWuuw">Online Careers Journey</a>
+                                    </th>
+                                    <td class="dfeuk-table__cell">Discovery</td>
+                                    <td class="dfeuk-table__cell">12 Oct 2023</td>
+                                    <td class="dfeuk-table__cell">12 Oct 2023</td>
+                                </tr>
+
+                                <tr class="dfeuk-table__row">
+                                    <th scope="row" class="dfeuk-table__header">
+                                        <a href="/book/draft/rec1DZN2xuTgYRSS3">Mickey mouse discovery</a>
+                                    </th>
+                                    <td class="dfeuk-table__cell">Discovery</td>
+                                    <td class="dfeuk-table__cell">12 Oct 2023</td>
+                                    <td class="dfeuk-table__cell">12 Oct 2023</td>
+                                </tr>
+
+                                <tr class="dfeuk-table__row">
+                                    <th scope="row" class="dfeuk-table__header">
+                                        <a href="/book/draft/recLMhT3rV7sm9Hgy">Service assessment plus - redesign</a>
+                                    </th>
+                                    <td class="dfeuk-table__cell">Discovery</td>
+                                    <td class="dfeuk-table__cell">25 Oct 2023</td>
+                                    <td class="dfeuk-table__cell">26 Oct 2023</td>
+                                </tr>
+
+                            </tbody>
+                        </table>
+                    </div>
+                </div> *@
+
+
+                <h2 class="govuk-heading-l">Before you start</h2>
+                <p>Read the <a href="https://dfe-standards-manual-prototype.herokuapp.com/service-assurance/" target="_blank"> step by step guidance</a> to help you understand what a discovery peer review is, how to prepare and what to expect.</p>
+                <h3 class="govuk-heading-s">If you need help using the service</h3>
+                <p>Contact the <a href="/">service assessment team</a>.</p>
+
+            </div>
+
+            <div class="govuk-grid-column-one-third">
+                <aside class="govuk-related-navigation">
+                    <h2 class="govuk-heading-m">Other resources and guidance</h2>
+                    <ul class="govuk-list govuk-list--spaced">
+                        <li>
+                            <a href="https://apply-the-service-standard.education.gov.uk/" target="_blank">Apply the Service Standard in DfE</a>
+                        </li>
+                        <li>
+                            <a href="https://design.education.gov.uk/" target="_blank">Design Manual</a>
+                        </li>
+                        <li>
+                            <a href="https://user-research.education.gov.uk/" target="_blank">User Research in DfE</a>
+                        </li>
+                        <li>
+                            <a href="https://technical-guidance.education.gov.uk/" target="_blank">DfE Technical Guidance</a>
+                        </li>
+                        <li>
+                            <a href="https://dfe-digital.github.io/architecture/#dfe-architecture" target="_blank">DfE Architecture</a>
+                        </li>
+                        <li>
+                            <a href="https://design-system.service.gov.uk/" target="_blank">GOV.UK Design System</a>
+                        </li>
+                        <li>
+                            <a href="https://www.gov.uk/service-manual" target="_blank">GOV.UK Service Manual</a>
+                        </li>
+                        <li>
+                            <a href="https://www.gov.uk/service-manual/communities/design-community" target="_blank">Cross government design community</a>
+                        </li>
+                    </ul>
+                </aside>
+            </div>
+        </div>
+    </div>
+</div>

--- a/src/ServiceAssessmentService/ServiceAssessmentService.WebApp/Views/Shared/_Layout.cshtml
+++ b/src/ServiceAssessmentService/ServiceAssessmentService.WebApp/Views/Shared/_Layout.cshtml
@@ -163,7 +163,7 @@
         <h2 class="sidebar-title">All assessments</h2>
         <ul class="sidebar-nav">
             <li>
-                <a href="/book" class="">Book an assessment</a>
+                <a href="/book/index" class="">Book an assessment</a>
             </li>
             <li>
                 <a href="/generic/assessments" class="">Upcoming assessments</a>


### PR DESCRIPTION
This pull request adds static HTML (per the prototype) for the entry page to the "book an assessment" page.

It does have some broken links and the markup likely benefits from some polishing/refinement, but this can be done via follow-up PR (see checklist in #1).

#1