### PR TITLE
Add `rel="noopener"` to external links

### DIFF
--- a/src/ServiceAssessmentService/ServiceAssessmentService.WebApp/Views/Book/Index.cshtml
+++ b/src/ServiceAssessmentService/ServiceAssessmentService.WebApp/Views/Book/Index.cshtml
@@ -98,7 +98,7 @@
 
 
                 <h2 class="govuk-heading-l">Before you start</h2>
-                <p>Read the <a href="https://dfe-standards-manual-prototype.herokuapp.com/service-assurance/" target="_blank"> step by step guidance</a> to help you understand what a discovery peer review is, how to prepare and what to expect.</p>
+                <p>Read the <a href="https://dfe-standards-manual-prototype.herokuapp.com/service-assurance/" target="_blank" rel="noopener"> step by step guidance</a> to help you understand what a discovery peer review is, how to prepare and what to expect.</p>
                 <h3 class="govuk-heading-s">If you need help using the service</h3>
                 <p>Contact the <a href="/">service assessment team</a>.</p>
 
@@ -109,28 +109,28 @@
                     <h2 class="govuk-heading-m">Other resources and guidance</h2>
                     <ul class="govuk-list govuk-list--spaced">
                         <li>
-                            <a href="https://apply-the-service-standard.education.gov.uk/" target="_blank">Apply the Service Standard in DfE</a>
+                            <a href="https://apply-the-service-standard.education.gov.uk/" target="_blank" rel="noopener">Apply the Service Standard in DfE</a>
                         </li>
                         <li>
-                            <a href="https://design.education.gov.uk/" target="_blank">Design Manual</a>
+                            <a href="https://design.education.gov.uk/" target="_blank" rel="noopener">Design Manual</a>
                         </li>
                         <li>
-                            <a href="https://user-research.education.gov.uk/" target="_blank">User Research in DfE</a>
+                            <a href="https://user-research.education.gov.uk/" target="_blank" rel="noopener">User Research in DfE</a>
                         </li>
                         <li>
-                            <a href="https://technical-guidance.education.gov.uk/" target="_blank">DfE Technical Guidance</a>
+                            <a href="https://technical-guidance.education.gov.uk/" target="_blank" rel="noopener">DfE Technical Guidance</a>
                         </li>
                         <li>
-                            <a href="https://dfe-digital.github.io/architecture/#dfe-architecture" target="_blank">DfE Architecture</a>
+                            <a href="https://dfe-digital.github.io/architecture/#dfe-architecture" target="_blank" rel="noopener">DfE Architecture</a>
                         </li>
                         <li>
-                            <a href="https://design-system.service.gov.uk/" target="_blank">GOV.UK Design System</a>
+                            <a href="https://design-system.service.gov.uk/" target="_blank" rel="noopener">GOV.UK Design System</a>
                         </li>
                         <li>
-                            <a href="https://www.gov.uk/service-manual" target="_blank">GOV.UK Service Manual</a>
+                            <a href="https://www.gov.uk/service-manual" target="_blank" rel="noopener">GOV.UK Service Manual</a>
                         </li>
                         <li>
-                            <a href="https://www.gov.uk/service-manual/communities/design-community" target="_blank">Cross government design community</a>
+                            <a href="https://www.gov.uk/service-manual/communities/design-community" target="_blank" rel="noopener">Cross government design community</a>
                         </li>
                     </ul>
                 </aside>

--- a/src/ServiceAssessmentService/ServiceAssessmentService.WebApp/Views/Home/Dashboard.cshtml
+++ b/src/ServiceAssessmentService/ServiceAssessmentService.WebApp/Views/Home/Dashboard.cshtml
@@ -109,25 +109,25 @@
                 <h2 class="govuk-heading-m">Profession-specific guidance</h2>
                 <ul class="govuk-list govuk-list--spaced">
                     <li>
-                        <a href="https://apply-the-service-standard.education.gov.uk/" target="_blank">Apply the Service Standard in DfE</a>
+                        <a href="https://apply-the-service-standard.education.gov.uk/" target="_blank" rel="noopener">Apply the Service Standard in DfE</a>
                     </li>
                     <li>
-                        <a href="https://user-research.education.gov.uk/" target="_blank">User Research in DfE</a>
+                        <a href="https://user-research.education.gov.uk/" target="_blank" rel="noopener">User Research in DfE</a>
                     </li>
                     <li>
-                        <a href="https://technical-guidance.education.gov.uk/" target="_blank">DfE Technical Guidance</a>
+                        <a href="https://technical-guidance.education.gov.uk/" target="_blank" rel="noopener">DfE Technical Guidance</a>
                     </li>
                     <li>
-                        <a href="https://dfe-digital.github.io/architecture/#dfe-architecture" target="_blank">DfE Architecture</a>
+                        <a href="https://dfe-digital.github.io/architecture/#dfe-architecture" target="_blank" rel="noopener">DfE Architecture</a>
                     </li>
                     <li>
-                        <a href="https://design-system.service.gov.uk/" target="_blank">GOV.UK Design System</a>
+                        <a href="https://design-system.service.gov.uk/" target="_blank" rel="noopener">GOV.UK Design System</a>
                     </li>
                     <li>
-                        <a href="https://www.gov.uk/service-manual" target="_blank">GOV.UK Service Manual</a>
+                        <a href="https://www.gov.uk/service-manual" target="_blank" rel="noopener">GOV.UK Service Manual</a>
                     </li>
                     <li>
-                        <a href="https://www.gov.uk/service-manual/communities/design-community" target="_blank">Cross government design community</a>
+                        <a href="https://www.gov.uk/service-manual/communities/design-community" target="_blank" rel="noopener">Cross government design community</a>
                     </li>
                 </ul>
             </div>


### PR DESCRIPTION
This issue is reported in SonarCloud analysis.

Adding ` rel="noopener"` removes potential risk of newly opened windows having access to the opening page via JavaScript.