### PR TITLE
Revert #158 updating to govuk-frontend v5 

### DIFF
--- a/src/ServiceAssessmentService/ServiceAssessmentService.WebApp/ServiceAssessmentService.WebApp.csproj
+++ b/src/ServiceAssessmentService/ServiceAssessmentService.WebApp/ServiceAssessmentService.WebApp.csproj
@@ -7,6 +7,7 @@
   <PropertyGroup Condition=" '$(RunConfiguration)' == 'https' " />
   <PropertyGroup Condition=" '$(RunConfiguration)' == 'http' " />
   <ItemGroup>
+    <!-- Note C# dependency `GovUk.Frontend.AspNetCore` currently only supports node dependency `govuk-frontend` to v4.7.0 preventing upgrade to v5 -->
     <PackageReference Include="GovUk.Frontend.AspNetCore" Version="1.4.0" />
   </ItemGroup>
 </Project>

--- a/src/ServiceAssessmentService/ServiceAssessmentService.WebApp/package-lock.json
+++ b/src/ServiceAssessmentService/ServiceAssessmentService.WebApp/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "dfe-frontend-alpha": "^1.0.1",
-        "govuk-frontend": "^5.0.0"
+        "govuk-frontend": "^4.7.0"
       },
       "devDependencies": {
         "copy-webpack-plugin": "^12.0.2",
@@ -5073,14 +5073,6 @@
         "node": "18.x"
       }
     },
-    "node_modules/dfe-frontend-alpha/node_modules/govuk-frontend": {
-      "version": "4.7.0",
-      "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-4.7.0.tgz",
-      "integrity": "sha512-0OsdCusF5qvLWwKziU8zqxiC0nq6WP0ZQuw51ymZ/1V0tO71oIKMlSLN2S9bm8RcEGSoidPt2A34gKxePrLjvg==",
-      "engines": {
-        "node": ">= 4.2.0"
-      }
-    },
     "node_modules/diff-sequences": {
       "version": "26.6.2",
       "resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-26.6.2.tgz",
@@ -6665,9 +6657,9 @@
       }
     },
     "node_modules/govuk-frontend": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-5.0.0.tgz",
-      "integrity": "sha512-3WSfvQ+3kw/q/m8jrq/t8XnMUA8D2r0uhGyZaDbIh1gWTJBQzJBHbHiKYI9nc9ixIXdCFsc9RozkgEm57a795g==",
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-4.7.0.tgz",
+      "integrity": "sha512-0OsdCusF5qvLWwKziU8zqxiC0nq6WP0ZQuw51ymZ/1V0tO71oIKMlSLN2S9bm8RcEGSoidPt2A34gKxePrLjvg==",
       "engines": {
         "node": ">= 4.2.0"
       }
@@ -19766,13 +19758,6 @@
         "wait-on": "^6.0.0",
         "webpack": "^5.74.0",
         "webpack-stream": "^5.2.1"
-      },
-      "dependencies": {
-        "govuk-frontend": {
-          "version": "4.7.0",
-          "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-4.7.0.tgz",
-          "integrity": "sha512-0OsdCusF5qvLWwKziU8zqxiC0nq6WP0ZQuw51ymZ/1V0tO71oIKMlSLN2S9bm8RcEGSoidPt2A34gKxePrLjvg=="
-        }
       }
     },
     "diff-sequences": {
@@ -21032,9 +21017,9 @@
       }
     },
     "govuk-frontend": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-5.0.0.tgz",
-      "integrity": "sha512-3WSfvQ+3kw/q/m8jrq/t8XnMUA8D2r0uhGyZaDbIh1gWTJBQzJBHbHiKYI9nc9ixIXdCFsc9RozkgEm57a795g=="
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-4.7.0.tgz",
+      "integrity": "sha512-0OsdCusF5qvLWwKziU8zqxiC0nq6WP0ZQuw51ymZ/1V0tO71oIKMlSLN2S9bm8RcEGSoidPt2A34gKxePrLjvg=="
     },
     "graceful-fs": {
       "version": "4.2.11",

--- a/src/ServiceAssessmentService/ServiceAssessmentService.WebApp/package.json
+++ b/src/ServiceAssessmentService/ServiceAssessmentService.WebApp/package.json
@@ -6,7 +6,7 @@
   "version": "0.0.1",
   "dependencies": {
     "dfe-frontend-alpha": "^1.0.1",
-    "govuk-frontend": "^5.0.0"
+    "govuk-frontend": "^4.7.0" 
   },
   "devDependencies": {
     "copy-webpack-plugin": "^12.0.2",

--- a/src/ServiceAssessmentService/ServiceAssessmentService.WebApp/wwwroot/css/site.scss
+++ b/src/ServiceAssessmentService/ServiceAssessmentService.WebApp/wwwroot/css/site.scss
@@ -1,4 +1,4 @@
-﻿@import "node_modules/govuk-frontend/dist/govuk/all";
+﻿@import "node_modules/govuk-frontend/govuk/all";
 @import "node_modules/dfe-frontend-alpha/packages/dfefrontend";
 
 
@@ -37,3 +37,94 @@ tr {
   font-family: BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen-Sans, Ubuntu, Cantarell, 'Helvetica Neue', sans-serif !important;
 }
 
+
+// Task list pattern
+// TODO: Update to govuk-frontend v5 to incorporate the new task list pattern
+// https://github.com/alphagov/govuk-prototype-kit/blob/main/lib/assets/sass/patterns/_task-list.scss
+
+.app-task-list {
+  list-style-type: none;
+  padding-left: 0;
+  margin-top: 0;
+  margin-bottom: 0;
+  @include govuk-media-query($from: tablet) {
+    min-width: 550px;
+  }
+}
+
+.app-task-list__section {
+  display: table;
+  @include govuk-font($size:24, $weight: bold);
+}
+
+.app-task-list__section-number {
+  display: table-cell;
+
+  @include govuk-media-query($from: tablet) {
+    min-width: govuk-spacing(6);
+    padding-right: 0;
+  }
+}
+
+.app-task-list__items {
+  @include govuk-font($size: 19);
+  @include govuk-responsive-margin(9, "bottom");
+  list-style: none;
+  padding-left: 0;
+  @include govuk-media-query($from: tablet) {
+    padding-left: govuk-spacing(6);
+  }
+}
+
+.app-task-list__item {
+  border-bottom: 1px solid $govuk-border-colour;
+  margin-bottom: 0 !important;
+  padding-top: govuk-spacing(2);
+  padding-bottom: govuk-spacing(2);
+  @include govuk-clearfix;
+}
+
+.app-task-list__item:first-child {
+  border-top: 1px solid $govuk-border-colour;
+}
+
+.app-task-list__task-name {
+  display: block;
+  @include govuk-media-query($from: 450px) {
+    float: left;
+  }
+}
+
+// The `app-task-list__task-completed` class was previously used on the task
+// list for the completed tag (changed in 86c90ec) – it's still included here to
+// avoid breaking task lists in existing prototypes.
+.app-task-list__tag,
+.app-task-list__task-completed {
+  margin-top: govuk-spacing(2);
+  margin-bottom: govuk-spacing(1);
+
+  @include govuk-media-query($from: 450px) {
+    float: right;
+    margin-top: 0;
+    margin-bottom: 0;
+  }
+}
+
+
+// Custom "three-column" task list
+// Specific to the Service Assessment Service, where the value is displayed within the centre column
+
+.app-task-list__item .app-task-list__task-name {
+  width: 30%;
+  display: inline-block
+}
+
+.app-task-list__item .app-task-list__task-value {
+  display: inline-block;
+  width: 49%
+}
+
+.app-task-list__item .app-task-list__task-tag {
+  display: inline-block;
+  width: 20%
+}


### PR DESCRIPTION
- dependency `govuk-frontend-aspnetcore` currently supports only to v4.7.0
- appears to be incompatible with radio conditionals for example
- additional work likely required for library to be compatible with v5

This PR, therefore, reverts changes made in #158 